### PR TITLE
Fix exports of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-as-browser",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Make electron like browser easy and flexible.",
   "keywords": [
     "electron",
@@ -9,7 +9,7 @@
     "tab",
     "addressbar"
   ],
-  "exports": "./index.js",
+  "main": "index.ts",
   "author": "hui.liu",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,18 @@
     "tab",
     "addressbar"
   ],
-  "main": "index.ts",
-  "author": "hui.liu",
+  "exports": {
+    ".": "./dist/index.js",
+    "./*": "./dist/*.js"
+  },
+  "author": "lilac",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hulufei/electron-as-browser.git"
   },
   "files": [
+    "dist",
     "*.js",
     "*.ts"
   ],
@@ -25,7 +29,8 @@
     "docs": "documentation build *.js -f html -o docs",
     "control:build": "esbuild --bundle --platform=node --packages=external example/renderer/control.tsx --outfile=example/renderer/control-compiled.js",
     "example:build": "esbuild --bundle --platform=node --format=esm --packages=external example/main.ts --outfile=example/main-bundle.js",
-    "start": "electron example/main-bundle.js"
+    "start": "electron example/main-bundle.js",
+    "build": "tsc"
   },
   "dependencies": {
     "electron-log": "^3.0.7"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,13 +50,13 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
The `exports` field is misused, causing files other than `index.ts` not being able to be imported.